### PR TITLE
update bgen repository link

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -6,7 +6,7 @@ The **regenie** source code is hosted on
 ##Installation
 
 1. **regenie** requires the
-  [BGEN library](https://bitbucket.org/gavinband/bgen/src/default/) so
+  [BGEN library](https://enkre.net/cgi-bin/code/bgen/dir?ci=trunk) so
   you will need to download and install that library.
 2. In the source code edit the BGEN_PATH variable in the `Makefile`
    to the BGEN library path.


### PR DESCRIPTION
there is a notice about the repo moving on https://bitbucket.org/gavinband/bgen/src/master/, however the current link to bitbucket is broken