### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.dockerignore
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:20.04 AS builder
+
+RUN apt update && apt install -y --no-install-recommends\
+  g++ \
+  make \
+  python3 \
+  zlib1g-dev
+
+WORKDIR /src
+
+ADD http://code.enkre.net/bgen/tarball/release/v1.1.7 v1.1.7.tgz
+
+RUN tar -xzf v1.1.7.tgz \
+ && cd v1.1.7 \
+ && python3 waf configure \
+ && python3 waf
+
+COPY . /src/regenie
+
+WORKDIR /src/regenie
+
+RUN make BGEN_PATH=/src/v1.1.7
+
+FROM ubuntu:20.04
+
+RUN apt update && apt install -y --no-install-recommends libgomp1 \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/regenie/regenie /usr/local/bin
+
+ENTRYPOINT ["/usr/local/bin/regenie"]


### PR DESCRIPTION
While attempting to compile regenie for a local user, I thought it would be useful to document the steps in a Dockerfile to allow regenie to facilitate reproducible builds, as well as allow for easier regression testing; e.g., the current version of regenie (commit be32102ecf524ce28b9a2adbcd80c446dfe57b44) fails to build:

```
$ docker build -t regenie:latest .
...
#13 227.5 /usr/bin/ld: cannot find -lboost_program_options
#13 227.5 collect2: error: ld returned 1 exit status
#13 227.5 make: *** [Makefile:33: regenie] Error 1
```

Whereas when this Dockerfile is used with commit f566da7b80bf0fc94fe2b9c2e4404061b41b6d17 , regenie successfully builds:

```
$ docker build -t regenie:latest .
...
 => => naming to docker.io/library/regenie:latest  
$ docker run -it--rm -v $PWD:/mnt -w /mnt regenie:latest
              |==================================|
              |           REGENIE v1.0.5.2       |    
              |==================================|

Copyright (c) 2020 Joelle Mbatchou and Jonathan Marchini.
Distributed under the MIT License.

ERROR :You must specify an output file with --o. 
For list of arguments, run with option --help
```

A multi-stage build is used to reduce the size of the final image.