### PR TITLE
help should return 0 when not failing

### DIFF
--- a/src/Regenie.cpp
+++ b/src/Regenie.cpp
@@ -190,11 +190,11 @@ void read_params_and_check(int argc, char *argv[], struct param* params, struct 
     if (vm.count("help")){
       print_header(std::cout);
       std::cout << AllOptions.help({"", "Main"}) << '\n' << webinfo << "\n\n";
-      exit(-1);
+      exit(0);
     } else if (vm.count("helpFull")) {
       print_header(std::cout);
       std::cout << AllOptions.help({"", "Main", "Additional"}) << '\n' << webinfo << "\n\n";
-      exit(-1);
+      exit(0);
     } 
     
     if (!vm.count("out")){


### PR DESCRIPTION
Usually it is considered bad practice to report unknown failure to the system when program prints help, therefore shouldn't return -1, but 0. Returning -1 would be ok in case the program actually fails to print the whole help for an unknown reason.