### PR TITLE
avoid resolving absolute path for loco_filename and prs_filename

### DIFF
--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -853,7 +853,6 @@ void Data::output() {
   int min_index;
   double performance_measure, rsq, sse, ll_avg, min_val;
   string pfile, out_blup_list, out_prs_list, loco_filename, prs_filename;
-  string fullpath_str, path_prs;
   Files outb, outp;
 
   sout << "Output\n" << "------\n";
@@ -875,16 +874,13 @@ void Data::output() {
 
     if( params.make_loco || params.binary_mode || params.print_prs ) {
 
-      fullpath_str = get_fullpath(loco_filename);
-      if(params.print_prs) path_prs = get_fullpath(prs_filename);
-
       if( !params.binary_mode ) { // for quantitative traits
-        outb << files.pheno_names[ph]  << " " <<  fullpath_str << endl;
-        if(params.print_prs) outp << files.pheno_names[ph]  << " " <<  path_prs << endl;
+        outb << files.pheno_names[ph]  << " " <<  loco_filename << endl;
+        if(params.print_prs) outp << files.pheno_names[ph]  << " " <<  prs_filename << endl;
       } else { // for binary traits - check level 1 ridge converged
         if( !l1_ests.pheno_l1_not_converged(ph) ) {
-          outb << files.pheno_names[ph]  << " " << fullpath_str << endl;
-          if(params.print_prs) outp << files.pheno_names[ph]  << " " <<  path_prs << endl;
+          outb << files.pheno_names[ph]  << " " << loco_filename << endl;
+          if(params.print_prs) outp << files.pheno_names[ph]  << " " <<  prs_filename << endl;
         } else {
           if(params.write_l0_pred) rm_l0_files(ph); // cleanup level 0 predictions
           sout << "Level 1 logistic did not converge. LOCO predictions calculations are skipped.\n\n";


### PR DESCRIPTION
Hi,

This is a simple PR to use ``loco_filename`` and ``prs_filename`` as it is, i.e. without introducing full file names to the ``<out>.step1_pred.list``. In my environment I have to manually modify the ``<out>.step1_pred.list`` file generated by ``regenie``, because it the full paths had some artifacts -it seem that they to resolved to some internal mount or symbolic links used on my HPC cluster, and those links were specific to compute nodes (not accessible from login nodes), perhaps even specific to the compute node where the job was executed.

I agree that general best practice is to use full file names. But it is the user of the regenie software who needs to comply with  it  and provide the full file name as ``--out`` argument. There might be complex reasons to use relative paths, e.g. when binding folders to singularity containers (with explicit read/write modes), or due to symbolic links. As far as ``regenie`` is concerned, the files are written to ``<out>.step1_<index>.loco``. I think "less is more" here, and it's better to use ``<out>`` prefix as it is, without resolving it to full paths. 

Would you agree with my arguments, or do I miss some important scenarios when resolving to full paths is beneficial?