### PR TITLE
openmp parallel for loop in fit_null_firth

### DIFF
--- a/src/Step2_Models.cpp
+++ b/src/Step2_Models.cpp
@@ -443,7 +443,12 @@ void fit_null_firth(bool const& silent, int const& chrom, struct f_ests* firth_e
     get_beta_start_firth(chrom, firth_est, files, params, sout);
   //cerr << firth_est->beta_null_firth.topRows(3) << "\n\n\n";
 
-  for( int i = 0; i < params->n_pheno; ++i ) {
+  const auto n_pheno = params->n_pheno;
+#if defined(_OPENMP)
+  setNbThreads(1);
+#pragma omp parallel for schedule(dynamic) shared(m_ests, firth_est, sout)
+#endif
+  for( int i = 0; i < n_pheno; ++i ) {
     bool has_converged = fit_firth_logistic(chrom, i, true, params, pheno_data, m_ests, firth_est, sout);
     if(!has_converged) {
       string msg1 = to_string( (params->fix_maxstep_null ? params->maxstep_null : params->retry_maxstep_firth) );

--- a/src/Step2_Models.cpp
+++ b/src/Step2_Models.cpp
@@ -462,6 +462,9 @@ void fit_null_firth(bool const& silent, int const& chrom, struct f_ests* firth_e
       (*firth_est->firth_est_files[i]) << chrom << " " << firth_est->beta_null_firth.block(0,i,params->ncov,1).transpose().format(Fmt) << endl;
     //cerr << firth_est->beta_null_firth.topRows(3) << "\n\n\n";
   }
+#if defined(_OPENMP)
+  setNbThreads(params->threads);
+#endif
 
   if(silent) return;
 


### PR DESCRIPTION
Hi,

We saw that the fit_null_firth function (actually fit_firth_nr) was only using about 8-9 cores (vCPUs) on systems with 96 cores. This is called when we use:

```
Compiled with Boost Iostream library.
Using Intel MKL with Eigen.


  --bt \
  --firth \
  --approx \
```

I wrapped the main loop in a `#pragma omp parallel for` when *_OPENMP* is available and saw a speed up of ~8x in our tests with 72 phenotypes; its utilization went from ~900% to ~6800%. 

This passes your tests, but I don't currently have tests that work with v2.2.2. I also made  the same changes to v2.0.1, which I do have extensive tests and existing runs for and the results are identical. So I don't think these changes have an effect on the results.

