### PR TITLE
allow chr prefix in data when using --chr or --range

### DIFF
--- a/src/Geno.cpp
+++ b/src/Geno.cpp
@@ -2507,17 +2507,26 @@ string bgi_chrList(struct filter* filters, const int& nChrom){// for --chr/--chr
   map<int, bool >::iterator itr;
 
   for (itr = filters->chrKeep_test.begin(); itr != filters->chrKeep_test.end(); ++itr) {
+    // add X and chrX format
     fmt = to_string(itr->first);
     clist.push_back( fmt );
+    fmt = "'chr" + to_string(itr->first) + "'";
+    clist.push_back( fmt );
 
-    if(itr->first < 10){ // add X and 0X format
+    if(itr->first < 10){ // add 0X and chr0x format
       fmt = "'0" + to_string(itr->first) + "'";
+      clist.push_back( fmt );
+      fmt = "'chr0" + to_string(itr->first) + "'";
       clist.push_back( fmt );
     } else if(itr->first == nChrom){ // add XY, X, PARs
       clist.push_back( "'X'" );
+      clist.push_back( "'chrX'" );
       clist.push_back( "'XY'" );
+      clist.push_back( "'chrXY'" );
       clist.push_back( "'PAR1'" );
+      clist.push_back( "'chrPAR1'" );
       clist.push_back( "'PAR2'" );
+      clist.push_back( "'chrPAR2'" );
     }
   }
 
@@ -2529,17 +2538,26 @@ string bgi_chrList(const int& range_chr, const int& nChrom){// for range
   string fmt = to_string(range_chr);
   vector<string> clist;
 
-  if(range_chr < 10){ // add X and 0X format
-    clist.push_back( fmt );
+  // add X and chrX format
+  clist.push_back( fmt );
+  fmt = "'chr" + to_string(range_chr) + "'";
+  clist.push_back( fmt );
+
+  if(range_chr < 10){ // add 0X and chr0X format
     fmt = "'0" + to_string(range_chr) + "'";
     clist.push_back( fmt );
-  } else if(range_chr == nChrom){ // add XY, X, Y
+    fmt = "'chr0" + to_string(range_chr) + "'";
     clist.push_back( fmt );
+  } else if(range_chr == nChrom){ // add XY, X, PARs
     clist.push_back( "'X'" );
+    clist.push_back( "'chrX'" );
     clist.push_back( "'XY'" );
+    clist.push_back( "'chrXY'" );
     clist.push_back( "'PAR1'" );
+    clist.push_back( "'chrPAR1'" );
     clist.push_back( "'PAR2'" );
-  } else return fmt;
+    clist.push_back( "'chrPAR2'" );
+  }
 
   return print_csv(clist);
 }


### PR DESCRIPTION
When running regenie using a bgen with a .bgi file and giving a --chr or --range argument, this fix will allow the data to contain a chr prefix in the chromosome name

A bgen file with variants like this works without this fix:

```
alternate_ids    rsid             chromosome  position  number_of_alleles  first_allele  alternative_alleles
chr20_61083_C_T  chr20_61083_C_T  20          61083     2                  C             T
```

With this fix a bgen file like this also works:
```
alternate_ids    rsid             chromosome  position  number_of_alleles  first_allele  alternative_alleles
chr20_61083_C_T  chr20_61083_C_T  chr20       61083     2                  C             T
```

Both kinds of data work without this fix when not using --chr or --range, or when not using a .bgi file
