### PR TITLE
Include <utility> in bgz_writer.cpp (remeta)

### DIFF
--- a/external_libs/remeta/bgz_writer.cpp
+++ b/external_libs/remeta/bgz_writer.cpp
@@ -1,5 +1,6 @@
 #ifdef WITH_HTSLIB
 #include "bgz_writer.hpp"
+#include <utility>
 
 using namespace std;
 


### PR DESCRIPTION
Stumbled on a compilation error in a ubuntu 24.04 docker container.

Error message excerpt:

```
bgz_writer.cpp:38:14: error: 'exchange' is not a member of 'std'
   38 |  , bgzf(std::exchange(other.bgzf, nullptr))
      |              ^~~~~~~~
bgz_writer.cpp:3:1: note: 'std::exchange' is defined in header '<utility>'; did you forget to '#include <utility>'?
    2 | #include "bgz_writer.hpp"
  +++ |+#include <utility>
    3 |
```
Cmake command used:
`BGEN_PATH=/src/v1.1.7 HAS_BOOST_IOSTREAM=TRUE HTSLIB_PATH=/usr/local/lib/ cmake .`

This commit fixes the issue