### PR TITLE
Accept PSAM files without FID column

### DIFF
--- a/src/Geno.cpp
+++ b/src/Geno.cpp
@@ -940,8 +940,8 @@ uint32_t read_pvar(map<string, vector<uint64>>& index_map, geno_file_info* ext_f
 
 void read_psam(struct in_files* files, struct param* params, mstream& sout) {
 
-  int lineread = 0, sex_col = 0;
-  bool col_found = false;
+  int lineread = 0, iid_col = 1, sex_col = 0;
+  bool col_found = false, has_fid = true;
   string line, tmp_id, fname;
   std::vector<int> sex;
   std::vector< string > tmp_str_vec, IDvec;
@@ -960,15 +960,23 @@ void read_psam(struct in_files* files, struct param* params, mstream& sout) {
     if( tmp_str_vec.size() < 1 )
       throw "no blank lines should be before the header line in psam file.";
 
-    if( tmp_str_vec[0] == "#IID" ) 
-      throw "invalid header (must start with #FID [not #IID]).";
-
-    if( tmp_str_vec[0] == "#FID" ) 
+    if( tmp_str_vec[0] == "#IID" ) {
+      has_fid = false;
+      iid_col = 0;
       break;
+    }
+
+    if( tmp_str_vec[0] == "#FID" ) {
+      has_fid = true;
+      iid_col = 1;
+      break;
+    }
   }
 
   // check header
-  if( (tmp_str_vec.size() < 2) || (tmp_str_vec[1] != "IID"))
+  if( has_fid && ((tmp_str_vec.size() < 2) || (tmp_str_vec[1] != "IID")) )
+    throw "header does not have the correct format.";
+  if( !has_fid && ((tmp_str_vec.size() < 1) || (tmp_str_vec[0] != "#IID")) )
     throw "header does not have the correct format.";
 
   // find if sex column is present
@@ -979,10 +987,16 @@ void read_psam(struct in_files* files, struct param* params, mstream& sout) {
   while (myfile.readLine(line)) {
     tmp_str_vec = string_split(line,"\t ");
 
-    if( tmp_str_vec.size() < 3 )
+    if( has_fid && (tmp_str_vec.size() < 2) )
+      throw "incorrectly formatted psam file at line " + to_string( lineread + 1 ) ;
+    if( !has_fid && (tmp_str_vec.size() < 1) )
+      throw "incorrectly formatted psam file at line " + to_string( lineread + 1 ) ;
+    if( col_found && ((int)tmp_str_vec.size() <= sex_col) )
       throw "incorrectly formatted psam file at line " + to_string( lineread + 1 ) ;
 
-    tmp_id = tmp_str_vec[0] + "_" + tmp_str_vec[1];
+    const string FID = has_fid ? tmp_str_vec[0] : "0";
+    const string IID = tmp_str_vec[iid_col];
+    tmp_id = FID + "_" + IID;
 
     // check duplicates -- if not, store in map
     if (in_map(tmp_id, params->FID_IID_to_ind)) 
@@ -990,8 +1004,8 @@ void read_psam(struct in_files* files, struct param* params, mstream& sout) {
 
     params->FID_IID_to_ind[ tmp_id ] = lineread;
     if(params->write_samples || params->write_masks) {
-      IDvec[0] = tmp_str_vec[0];
-      IDvec[1] = tmp_str_vec[1];
+      IDvec[0] = FID;
+      IDvec[1] = IID;
       params->FIDvec.push_back(IDvec);
     }
 
@@ -1015,6 +1029,8 @@ void read_psam(struct in_files* files, struct param* params, mstream& sout) {
 uint32_t read_psam(struct ext_geno_info& ginfo, geno_file_info* ext_file_info, Ref<ArrayXb> mask, struct param* params, mstream& sout) {
 
   uint32_t position;
+  int iid_col = 1;
+  bool has_fid = true;
   string line, fname;
   std::vector< string > tmp_str_vec, tmp_ids;
   Files myfile;
@@ -1028,21 +1044,31 @@ uint32_t read_psam(struct ext_geno_info& ginfo, geno_file_info* ext_file_info, R
     tmp_str_vec = string_split(line,"\t ");
     if( tmp_str_vec.size() < 1 )
       throw "no blank lines should be before the header line in psam file.";
-    if( tmp_str_vec[0] == "#IID" ) 
-      throw "invalid header (must start with #FID [not #IID]).";
-    if( tmp_str_vec[0] == "#FID" ) 
+    if( tmp_str_vec[0] == "#IID" ) {
+      has_fid = false;
+      iid_col = 0;
       break;
+    }
+    if( tmp_str_vec[0] == "#FID" ) {
+      has_fid = true;
+      iid_col = 1;
+      break;
+    }
   }
 
   // check header
-  if( (tmp_str_vec.size() < 2) || (tmp_str_vec[1] != "IID"))
+  if( has_fid && ((tmp_str_vec.size() < 2) || (tmp_str_vec[1] != "IID")) )
+    throw "header does not have the correct format.";
+  if( !has_fid && ((tmp_str_vec.size() < 1) || (tmp_str_vec[0] != "#IID")) )
     throw "header does not have the correct format.";
 
   while (myfile.readLine(line)) {
     tmp_str_vec = string_split(line,"\t ");
-    if( tmp_str_vec.size() < 2 )
+    if( has_fid && (tmp_str_vec.size() < 2) )
       throw "incorrectly formatted psam file at line " + to_string( tmp_ids.size() + 1 ) ;
-    tmp_ids.push_back(tmp_str_vec[0] + "_" + tmp_str_vec[1]);
+    if( !has_fid && (tmp_str_vec.size() < 1) )
+      throw "incorrectly formatted psam file at line " + to_string( tmp_ids.size() + 1 ) ;
+    tmp_ids.push_back((has_fid ? tmp_str_vec[0] : "0") + "_" + tmp_str_vec[iid_col]);
   }
 
   myfile.closeFile();


### PR DESCRIPTION
Fixes #666

## Summary

- allow `.psam` headers that start with `#IID` when `#FID` is absent
- use an internal FID value of `0` for absent-FID PSAM samples
- apply the same header and ID handling to the primary PGEN reader and external PGEN reader
- keep malformed rows rejected, including rows missing a declared `SEX` column

## Validation

- `g++ -std=c++11 -fsyntax-only src/Geno.cpp -I./src -I./external_libs/pgenlib -I./external_libs/pgenlib/simde -I./external_libs/pgenlib/include -I./external_libs/cxxopts/include -I./external_libs/LBFGSpp/include -I./external_libs/eigen-3.4.0 -I./external_libs/remeta -I./external_libs -I/tmp/regenie-bgen-v1.1.7 -I/tmp/regenie-bgen-v1.1.7/genfile/include -I/tmp/regenie-bgen-v1.1.7/3rd_party/boost_1_55_0 -I/tmp/regenie-bgen-v1.1.7/3rd_party/zstd-1.1.0/lib -I/tmp/regenie-bgen-v1.1.7/db/include -I/tmp/regenie-bgen-v1.1.7/3rd_party/sqlite3` - passed; warnings only from existing vendored/old dependency headers
- `git diff --check HEAD~1..HEAD` - passed

## Not run

- Full local build/test suite was not run because `cmake` and `gfortran` are not installed in my local environment.
- Docker-based build/test was not run because the Docker daemon is unavailable locally.
